### PR TITLE
add object splitter to targets list

### DIFF
--- a/1_fetch/src/find_oldest_sites.R
+++ b/1_fetch/src/find_oldest_sites.R
@@ -1,3 +1,11 @@
+#' Identify oldest USGS gage
+#'
+#' Identifies the oldest USGS gage within a user-specified state and
+#' for a user-specified parameter
+#'
+#' @param state chr, two letter state abbreviation (e.g., "WI")
+#' @param parameter chr, six-digit USGS parameter code
+#'
 find_oldest_site <- function(state, parameter) {
   message(sprintf('  Inventorying sites in %s', state))
   sites <- dataRetrieval::whatNWISdata(
@@ -21,6 +29,27 @@ find_oldest_site <- function(state, parameter) {
     slice(1) # OK has two sites tied for first; just take one
   return(best_site)
 }
+
+#' Identify oldest USGS gage
+#'
+#' Identifies the oldest USGS gage for a vector of user-specified states and
+#' for a user-specified parameter
+#'
+#' @param states chr, vector of two letter state abbreviations (e.g., `c("WI", "MI")`)
+#' @param parameter chr, six-digit USGS parameter code
+#'
 find_oldest_sites <- function(states, parameter) {
   purrr::map_df(states, find_oldest_site, parameter)
 }
+
+#' Generate state inventory
+#'
+#' Takes a table of gage metadata for and returns data for user-selected state
+#'
+#' @param sites_info table for NWIS state data
+#' @param state chr, two letter state abbreviation
+#'
+get_state_inventory <- function(sites_info, state) {
+  site_info <- dplyr::filter(sites_info, state_cd == state)
+}
+

--- a/_targets.R
+++ b/_targets.R
@@ -23,7 +23,8 @@ list(
     values = tibble(state_abb = states),
 
     # pull site data
-    tar_target(nwis_data, get_site_data(sites_info = oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, get_state_inventory(sites_info = oldest_active_sites, state_abb)),
+    tar_target(nwis_data, get_site_data(sites_info = nwis_inventory, state_abb, parameter))
 
     # tally data
 


### PR DESCRIPTION
Adding a splitter function to the targets list to improve workflow efficiency. Adding the splitter prevents the pipeline from re-querying the data for each state.