### PR TITLE
completion of splitter exercise

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
+  # site_info <- filter(sites_info, state_cd == state)
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -11,7 +11,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -24,7 +24,7 @@ list(
 
     # pull site data
     tar_target(nwis_inventory, get_state_inventory(sites_info = oldest_active_sites, state_abb)),
-    tar_target(nwis_data, get_site_data(sites_info = nwis_inventory, state_abb, parameter))
+    tar_target(nwis_data, get_site_data(site_info = nwis_inventory, state_abb, parameter))
 
     # tally data
 


### PR DESCRIPTION
I got a little ahead of myself on this one and submitted the first PR too early. This PR completes the splitter exercise.

When I update my pipeline to include more states (e.g. `c('WI','MN','MI')` to `('WI','MN','MI', 'IL', 'IN', 'IA')`) the `nwis_inventory_*` targets become outdated because the vector of state abbreviations (`states` object) has been updated. All sites are inventoried and all `nwis_inventory_*` targets are rebuilt because they're downstream of `oldest_active_sites` which uses the udpated `states` object.

The `nwis_data_*` targets do not rebuild for states that were included in the first run ("WI", "MN", "MI") because they are preserved from a previous run and there has been no change to the upstream object that is used to query the data (`nwis_inventory_wi`, `nwis_inventory_mn`, `nwis_inventory_mi`). `nwis_data_IN` and `nwis_data_IA` do build because `nwis_inventory_IN` and `nwis_inventory_IA` did not exist in a previous run.

`site_map_ong` also rebuilds because two new states were added to the map (IA, and IL).

![image](https://user-images.githubusercontent.com/15007294/139740517-ec724101-641e-4162-832e-0c6f43a594be.png)




I was surprised to see that the `visnetwork` doesn't quite reflect this nuance:
![image](https://user-images.githubusercontent.com/15007294/139739356-9f1cd169-4174-4b59-af7b-c512ebfd56ce.png)
