### PR TITLE
Appliers

### DIFF
--- a/3_visualize/src/plot_site_data.R
+++ b/3_visualize/src/plot_site_data.R
@@ -7,7 +7,8 @@ plot_site_data <- function(out_file, site_data, parameter) {
     geom_line() +
     geom_point(data=filter(site_data, !(Quality %in% c('A','P'))), size=0.1) +
     ylab(dataRetrieval::parameterCdFile %>% filter(parameter_cd == parameter) %>% pull(parameter_nm)) +
-    ggtitle(site_data$Site[1])
+    ggtitle(with(site_data, paste(State[1], " (Gage # ", Site[1], ")", sep = ""))) +
+    theme(plot.title = element_text(hjust = 0.5))
   ggsave(out_file, plot=p, width=6, height=3)
   return(out_file)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -1,14 +1,18 @@
+suppressPackageStartupMessages(library(dplyr))
 library(targets)
 library(tarchetypes)
 library(tibble)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot"))
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
+                            "rnaturalearth", "cowplot", "lubridate"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
+source("2_process/src/tally_site_obs.R")
 source("3_visualize/src/map_sites.R")
+source("3_visualize/src/plot_site_data.R")
 
 # Configuration
 states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
@@ -20,15 +24,23 @@ list(
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
   tar_map(
-    values = tibble(state_abb = states),
+    values = tibble(state_abb = states) %>%
+      mutate(state_plot_files = sprintf("3_visualize/out/timesseries_%s.png", state_abb)),
 
     # pull site data
-    tar_target(nwis_inventory, get_state_inventory(sites_info = oldest_active_sites, state_abb)),
-    tar_target(nwis_data, get_site_data(site_info = nwis_inventory, state_abb, parameter))
+    tar_target(nwis_inventory,
+               get_state_inventory(sites_info = oldest_active_sites, state_abb)),
+    tar_target(nwis_data,
+               get_site_data(site_info = nwis_inventory, state_abb, parameter)),
 
     # tally data
+    tar_target(tally, tally_site_obs(site_data = nwis_data)),
 
     # plot data
+    tar_target(timeseries_png,
+               plot_site_data(out_file = state_plot_files,
+                              site_data = nwis_data, parameter = parameter)),
+    names = state_abb
   ),
 
   # Map oldest sites


### PR DESCRIPTION
This pull request adds two appliers to the pipeline: `tally` and `plot`

* The `tally` step returns a tabular summary of observations by site, state, and year for each site of interest.

* The `plot` step plots the data for each site of interest, differentiating between data quality at each site (e.g., "A" or approved data plots as a different series than "P" or provisional data).