### PR TITLE
Combiners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 # Specific files/dirs to ignore for this pipeline
 */tmp/*
 */out/*
-*/log/*
 /_targets/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 # Specific files/dirs to ignore for this pipeline
 */tmp/*
 */out/*
+*/log/*
 /_targets/*

--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,10 @@
+#' @param ind_file str, output path for the indicator file
+#' @param ... `targets` to be included in the indicator file. Added as unquoted names
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>%
+    select(tar_name = name, filepath = path, hash = data) %>%
+    mutate(filepath = unlist(filepath))
+
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,7 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+combine_obs_tallies <- function(...){
+  dplyr::bind_rows(...)
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,7 @@
+tar_name,filepath,hash
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,b9ddce502f3d72e5
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,12a3b6c25085338f
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,5f0b363aec0eccb1
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,facfbd95003d5910
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,2ad7cca8286467bc
+timeseries_png_IA,3_visualize/out/timeseries_IA.png,c9773e6c98201e65

--- a/_targets.R
+++ b/_targets.R
@@ -9,8 +9,9 @@ library(tibble)
 library(tidyr)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
-                            "rnaturalearth", "cowplot", "lubridate"))
+tar_option_set(packages = c("cowplot", "dataRetrieval", "htmlwidgets",
+                            "rnaturalearth","leaflet", "leafpop",
+                            "lubridate","tidyverse", "urbnmapr"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")

--- a/_targets.R
+++ b/_targets.R
@@ -18,30 +18,37 @@ source("3_visualize/src/plot_site_data.R")
 states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
+# Static branching set-up
+mapped_by_state_targets <- tar_map(
+  values = tibble(state_abb = states) %>%
+    mutate(state_plot_files = sprintf("3_visualize/out/timesseries_%s.png", state_abb)),
+
+  # pull site data - inventory by state and then data
+  tar_target(nwis_inventory,
+             get_state_inventory(sites_info = oldest_active_sites, state_abb)),
+  tar_target(nwis_data,
+             get_site_data(site_info = nwis_inventory, state_abb, parameter)),
+
+  # tally data
+  tar_target(tally, tally_site_obs(site_data = nwis_data)),
+
+  # plot data
+  tar_target(timeseries_png,
+             plot_site_data(out_file = state_plot_files,
+                            site_data = nwis_data, parameter = parameter)),
+  names = state_abb,
+  unlist = FALSE
+)
+
 # Targets
 list(
   # Identify oldest sites
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
-  tar_map(
-    values = tibble(state_abb = states) %>%
-      mutate(state_plot_files = sprintf("3_visualize/out/timesseries_%s.png", state_abb)),
-
-    # pull site data
-    tar_target(nwis_inventory,
-               get_state_inventory(sites_info = oldest_active_sites, state_abb)),
-    tar_target(nwis_data,
-               get_site_data(site_info = nwis_inventory, state_abb, parameter)),
-
-    # tally data
-    tar_target(tally, tally_site_obs(site_data = nwis_data)),
-
-    # plot data
-    tar_target(timeseries_png,
-               plot_site_data(out_file = state_plot_files,
-                              site_data = nwis_data, parameter = parameter)),
-    names = state_abb
-  ),
+  # Combine static branches - calling the mapped targets and combining with custom fctn
+  mapped_by_state_targets,
+  tar_combine(obs_tallies, mapped_by_state_targets$tally,
+              command = combine_obs_tallies(!!!.x)),
 
   # Map oldest sites
   tar_target(


### PR DESCRIPTION
This commit accomplishes the following tasks in the `combiners` section of pipelines III:
* Combines observed tallies from a user-specified number of states into one summary table and produces a diagnostic plot;
* Summaries target output metadata data and saves it in a `log` subfolder for collaboration with others; and
* Generate a leaflet map for each site of interest that displays a pop-up of daily average flow data.